### PR TITLE
Fix compiler error on latest rust version

### DIFF
--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -149,8 +149,8 @@ fn render(
     _h.template()
         .ok_or_else(|| RenderError::new("Error with the handlebars template"))
         .and_then(|t| {
-            let mut local_rc = rc.clone();
             let local_ctx = Context::wraps(&context)?;
+            let mut local_rc = rc.clone();
             t.render(r, &local_ctx, &mut local_rc, out)
         })?;
 


### PR DESCRIPTION
👋
We use this branch to build the Dioxus docs, but it recently stopped working on the latest release of rust because of a compiler error about drop order. This PR fixes the error.